### PR TITLE
Add logHandler callback as option to handle logs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,6 +29,9 @@ function configureBinaryLog (opts) {
     let l = this.levels[level];
     if (l < this.levels[this.level]) return; // eslint-disable-line curly
     actualLog(level, prefix, msg);
+
+    // TODO: Callback function to handle logs
+    opts.logHandler && opts.logHandler(level, prefix, msg);
   };
   log.level = opts.debug ? 'debug' : 'info';
 }

--- a/test/util-specs.js
+++ b/test/util-specs.js
@@ -1,9 +1,10 @@
 // transpile:mocha
 
-import { pkgRoot } from '../lib/utils';
+import { pkgRoot, configureBinaryLog } from '../lib/utils';
 import { fs } from 'appium-support';
 import chai from 'chai';
 import path from 'path';
+import { Doctor } from '../lib/doctor';
 
 chai.should();
 
@@ -19,6 +20,16 @@ describe('utils', function () {
       'wow.txt'))).should.be.ok;
     (await fs.exists(path.resolve(pkgRoot, 'test', 'fixtures',
       'notwow.txt'))).should.not.be.ok;
+  });
+
+  it('Should handle logs through logHandler callback', function () {
+    function logHandler (level, prefix, msg) {
+      `${level} ${prefix} ${msg}`.should.include('AppiumDoctor');
+    }
+
+    configureBinaryLog({ logHandler });
+    let doctor = new Doctor();
+    doctor.run();
   });
 
 });


### PR DESCRIPTION
**Usage:**

```
function logHandler (level, prefix, msg) {
    `${level} ${prefix} ${msg}`.should.include('AppiumDoctor');
}

configureBinaryLog({ logHandler });
```